### PR TITLE
do not ignore cog files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@
 !weights/sample_weights/*
 !config.yml
 !setup.py
+!.cog/


### PR DESCRIPTION
Cog files need to be excluded from the `.dockerignore` file to build this locally. Otherwise it produces an error
```
 => ERROR [stage-0 2/6] COPY .cog/tmp/build1149978451/cog-0.0.1.dev-py3-none-any.whl /tmp/cog-  0.0s
------
 > [stage-0 2/6] COPY .cog/tmp/build1149978451/cog-0.0.1.dev-py3-none-any.whl /tmp/cog-0.0.1.dev-py3-none-any.whl:
------
failed to compute cache key: "/.cog/tmp/build1149978451/cog-0.0.1.dev-py3-none-any.whl" not found: not found
ⅹ Failed to build Docker image: exit status 1
```

This happens because some files needed by cog are [ignored by docker](https://stackoverflow.com/a/67928771/1128216).